### PR TITLE
Remove `schema=openid` parameter to user-info call to mitigate intermittent errors from Google API

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -38,6 +38,7 @@ function Strategy(options, verify) {
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
+  this._includeSchemaParamForOpenId = options.includeSchemaParamForOpenId || false;
 
   this._configurers = [];
 
@@ -191,7 +192,9 @@ Strategy.prototype.authenticate = function(req, options) {
 
           if (load) {
             var parsed = url.parse(config.userInfoURL, true);
-            parsed.query['schema'] = 'openid';
+            if (self._includeSchemaParamForOpenId) {
+              parsed.query['schema'] = 'openid';
+            }
             delete parsed.search;
             var userInfoURL = url.format(parsed);
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -38,7 +38,7 @@ function Strategy(options, verify) {
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
-  this._includeSchemaParamForOpenId = options.includeSchemaParamForOpenId || false;
+  this._disableSchemaParamForOpenId = options.disableSchemaParamForOpenId || false;
 
   this._configurers = [];
 
@@ -198,7 +198,7 @@ Strategy.prototype.authenticate = function(req, options) {
             // all available versions of the Google OAuth API (v1, v2, v3) and for any similar
             // parameter that we tried (schema, scope). Without the parameter, we see an expected
             // success rate and the same payload is returned.
-            if (self._includeSchemaParamForOpenId) {
+            if (!self._disableSchemaParamForOpenId) {
               parsed.query['schema'] = 'openid';
             }
             delete parsed.search;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -192,6 +192,12 @@ Strategy.prototype.authenticate = function(req, options) {
 
           if (load) {
             var parsed = url.parse(config.userInfoURL, true);
+
+            // As of 9/6/2018, we are seeing intermittent 400 response errors from Google when
+            // the `schema=openid` parameter is included in this API request. This is true accross
+            // all available versions of the Google OAuth API (v1, v2, v3) and for any similar
+            // parameter that we tried (schema, scope). Without the parameter, we see an expected
+            // success rate and the same payload is returned.
             if (self._includeSchemaParamForOpenId) {
               parsed.query['schema'] = 'openid';
             }


### PR DESCRIPTION
Use a conf-driven flag in case we need to start including it again quickly.

See: https://github.com/lever/hire2/pull/4436 for more context