### PR TITLE
Allow clientId and clientSecret to be customized per request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Node.js
 node_modules
 npm-debug.log
+
+# WebStorm
+.idea

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -31,6 +31,7 @@ function Strategy(options, verify) {
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
   this._scope = options.scope;
+  this._getClient = options.getClient;
   this._getScope = options.getScope;
   this._getPrompt = options.getPrompt;
   this._getAccessType = options.getAccessType;
@@ -95,10 +96,20 @@ Strategy.prototype.authenticate = function(req, options) {
 
   if (req.query && req.query.code) {
     var code = req.query.code;
-    req.googleAuthParams = {code: code}
+    req.googleAuthParams = {code: code};
 
     this.configure(null, function(err, config) {
       if (err) { return self.error(err); }
+
+      if(typeof self._getClient === 'function') {
+        var dynamicClient = self._getClient(req);
+        if(dynamicClient.clientID) {
+          config.clientID = dynamicClient.clientID;
+        }
+        if(dynamicClient.clientSecret) {
+          config.clientSecret = dynamicClient.clientSecret;
+        }
+      }
 
       var oauth2 = new OAuth2(config.clientID,  config.clientSecret,
                               '', config.authorizationURL, config.tokenURL);
@@ -317,6 +328,16 @@ Strategy.prototype.authenticate = function(req, options) {
 
     this.configure(identifier, function(err, config) {
       if (err) { return self.error(err); }
+
+      if(typeof self._getClient === 'function') {
+        var dynamicClient = self._getClient(req);
+        if(dynamicClient.clientID) {
+          config.clientID = dynamicClient.clientID;
+        }
+        if(dynamicClient.clientSecret) {
+          config.clientSecret = dynamicClient.clientSecret;
+        }
+      }
 
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {


### PR DESCRIPTION
This follows the pattern of our other additions to this module to suit
our needs by adding another functional option that will be called to
retrieve the clientId and clientSecret to be used for the request.

* Accept a `getClient` option to the `Strategy` constructor and save to
  a local `_getClient` path.
* Call the `this._getClient` to retrieve the `clientID` and
  `clientSecret` to use when instantiating the `OAuth` object.
* Add `.idea` to gitignore